### PR TITLE
Non api GET route for specific listings

### DIFF
--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -6,6 +6,9 @@ class App extends React.Component {
   constructor(props) {
     super(props);
   }
+  componentDidMount() {
+    console.log(window.location);
+  }
   render() {
     return (
       <div>Hello World!</div>
@@ -13,4 +16,4 @@ class App extends React.Component {
   }
 }
 
-ReacDOM.render(<App/>, document.getElementById('app'))
+ReacDOM.render(<App/>, document.getElementById('app'));

--- a/client/src/styles/style.css
+++ b/client/src/styles/style.css
@@ -1,6 +1,4 @@
-body {
-  background-color: red;
-}
+
 #app {
   text-align: center;
 }

--- a/public/dist/index.html
+++ b/public/dist/index.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="utf-8">
   <title>More</title>
-  <style rel="stylesheet" type="text/css" href="./style.css"></style>
+  <style rel="stylesheet" type="text/css" href="/style.css"></style>
 </head>
 <body>
 <div id="app"></div>
-<script src="./bundle.js"></script>
+<script src="/bundle.js"></script>
 </body>
 </html>

--- a/server/server.js
+++ b/server/server.js
@@ -11,6 +11,16 @@ app.use(bodyParser.urlencoded({extended: true}));
 
 const port = 3004;
 
+app.get('/listing/*', (req, res) => {
+  if (+req.params['0'] >= 1 && +req.params['0'] <= 100) {
+    res.status(200);
+    res.sendFile(path.join(__dirname, '../public/dist/index.html'));
+  } else {
+    res.status(404);
+    res.end();
+  }
+});
+
 // getting the related listings for a specific listing
 app.get('/api/more/listings/:id', (req, res) => {
   var listingId = req.params.id;


### PR DESCRIPTION
Added a non api get route for specific listings. Sends back index.html but changes url and refreshes page. Can make subsequent get calls to api using window.location() to get the current id.